### PR TITLE
implement proposed changes to image aligment, pause+exit code

### DIFF
--- a/decbinhex4/README.md
+++ b/decbinhex4/README.md
@@ -1,6 +1,6 @@
 # decbinhex4
 
-![A screenshot of the demo program. A text input reads 111A, 2 options are greyed out while one has been clicked: Convert from hexadecimal. A result box at the bottom says "Decimal is: 4378". There's also a binary result but I'm sure you believe me.](readme/decbinhex4_preview.png)
+<img align="right" src="readme/decbinhex4_preview.png" alt="A screenshot of the demo program. A text input reads 111A, 2 options are greyed out while one has been clicked: Convert from hexadecimal. A result box at the bottom says... Decimal is: 4378. There is also a binary result but I am sure you believe me."/>
 
 A number converter program, updated to Godot 4. Available functionality depends on text entered. Has limited live-conversion available.
 

--- a/dodge_the_creeps_2d/README.md
+++ b/dodge_the_creeps_2d/README.md
@@ -1,5 +1,7 @@
 # "Dodge the Creeps! 2D" with godot-nim
 
+<img align="right" src="art/dtc2d_preview.png" alt="A small and lonely creature trying its best to survive by avoiding a sea of other strange creatures."/>
+
 Back again, demonstrating the following concepts:
 - Node and scene structure
 - Instancing scenes
@@ -7,8 +9,6 @@ Back again, demonstrating the following concepts:
 - Signals
 - UI
 - Sounds
-
-![A small and lonely creature trying its best to survive by avoiding a sea of other strange creatures.](art/dtc2d_preview.png)
 
 ## Copying
 

--- a/dodge_the_creeps_2d/core/src/classes/player.nim
+++ b/dodge_the_creeps_2d/core/src/classes/player.nim
@@ -39,6 +39,13 @@ method ready(self: Player) {.gdsync.} =
 
 method process(self: Player; delta: float64) {.gdsync.} =
   if isRunningInEditor: return
+
+  if self.Input.isActionPressed "ui_cancel":
+    self.getTree.quit()
+  if self.Input.isActionJustPressed "pause_game":
+    self.get_tree().paused = not self.get_tree().paused
+  if self.get_tree().paused == true: return
+
   var velocity: Vector2
   if self.Input.isActionPressed "move_right":
     velocity.*x += 1

--- a/dodge_the_creeps_2d/project.godot
+++ b/dodge_the_creeps_2d/project.godot
@@ -26,25 +26,35 @@ window/stretch/mode="canvas_items"
 move_right={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
 ]
 }
 move_down={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
 ]
 }
 move_up={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
 ]
 }
 start_game={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194309,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+pause_game={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
 ]
 }


### PR DESCRIPTION
- HTML align right to dtc2d and decbinhex preview images
- add code to pause+exit
- changes to project.godot for input map, player process for said code to work
  - and add WASD control 

closes https://github.com/godot-nim/demo/issues/8